### PR TITLE
Convert ESP8266 examples to LittleFS and BearSSL Certstore

### DIFF
--- a/examples/esp8266/getCurrentlyPlaying/certs-from-mozilla.py
+++ b/examples/esp8266/getCurrentlyPlaying/certs-from-mozilla.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+# This script pulls the list of Mozilla trusted certificate authorities
+# from the web at the "mozurl" below, parses the file to grab the PEM
+# for each cert, and then generates DER files in a new ./data directory
+# Upload these to an on-chip filesystem and use the CertManager to parse
+# and use them for your outgoing SSL connections.
+#
+# Script by Earle F. Philhower, III.  Released to the public domain.
+from __future__ import print_function
+import csv
+import os
+import sys
+from subprocess import Popen, PIPE, call
+try:
+    from urllib.request import urlopen
+except:
+    from urllib2 import urlopen
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
+
+# Mozilla's URL for the CSV file with included PEM certs
+mozurl = "https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV"
+
+# Load the manes[] and pems[] array from the URL
+names = []
+pems = []
+response = urlopen(mozurl)
+csvData = response.read()
+if sys.version_info[0] > 2:
+    csvData = csvData.decode('utf-8')
+csvFile = StringIO(csvData)
+csvReader = csv.reader(csvFile)
+for row in csvReader:
+    names.append(row[0]+":"+row[1]+":"+row[2])
+    pems.append(row[30])
+del names[0] # Remove headers
+del pems[0] # Remove headers
+
+# Try and make ./data, skip if present
+try:
+    os.mkdir("data")
+except:
+    pass
+
+derFiles = []
+idx = 0
+# Process the text PEM using openssl into DER files
+for i in range(0, len(pems)):
+    certName = "data/ca_%03d.der" % (idx);
+    thisPem = pems[i].replace("'", "")
+    print(names[i] + " -> " + certName)
+    ssl = Popen(['openssl','x509','-inform','PEM','-outform','DER','-out', certName], shell = False, stdin = PIPE)
+    pipe = ssl.stdin
+    pipe.write(thisPem.encode('utf-8'))
+    pipe.close()
+    ssl.wait()
+    if os.path.exists(certName):
+        derFiles.append(certName)
+        idx = idx + 1
+
+if os.path.exists("data/certs.ar"):
+    os.unlink("data/certs.ar");
+
+arCmd = ['ar', 'q', 'data/certs.ar'] + derFiles;
+call( arCmd )
+
+for der in derFiles:
+    os.unlink(der)

--- a/examples/esp8266/getCurrentlyPlaying/getCurrentlyPlaying.ino
+++ b/examples/esp8266/getCurrentlyPlaying/getCurrentlyPlaying.ino
@@ -28,6 +28,12 @@
 
 #include <ESP8266WiFi.h>
 #include <WiFiClientSecure.h>
+#include <CertStoreBearSSL.h>
+#include <time.h>
+
+#define FS_NO_GLOBALS
+#include <FS.h>
+#include "LittleFS.h" // Required for BearSSL CertStore
 
 // ----------------------------
 // Additional Libraries - each one of these will need to be installed.
@@ -61,6 +67,31 @@ char clientSecret[] = "56t4373258u3405u43u543"; // Your client Secret of your sp
 
 //------- ---------------------- ------
 
+// A single, global CertStore which can be used by all
+// connections.  Needs to stay live the entire time any of
+// the WiFiClientBearSSLs are present.
+BearSSL::CertStore certStore;
+
+// Set time via NTP, as required for x.509 validation
+void setClock()
+{
+  configTime(3 * 3600, 0, "pool.ntp.org", "time.nist.gov");
+
+  Serial.print("Waiting for NTP time sync: ");
+  time_t now = time(nullptr);
+  while (now < 8 * 3600 * 2)
+  {
+      delay(500);
+      Serial.print(".");
+      now = time(nullptr);
+  }
+  Serial.println("");
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+  Serial.print("Current time: ");
+  Serial.print(asctime(&timeinfo));
+}
+
 WiFiClientSecure client;
 ArduinoSpotify spotify(client, clientId, clientSecret, SPOTIFY_REFRESH_TOKEN);
 
@@ -72,20 +103,34 @@ void setup() {
 
   Serial.begin(115200);
 
-    // Set WiFi to station mode and disconnect from an AP if it was Previously
-    // connected
-    WiFi.mode(WIFI_STA);
-    WiFi.disconnect();
-    delay(100);
+  // Initialise LittleFS, if this fails try .begin(true)
+  // NOTE: I believe this formats it though it will erase everything on
+  // spiffs already! In this example that is not a problem.
+  // I have found once I used the true flag once, I could use it
+  // without the true flag after that.
 
-    // Attempt to connect to Wifi network:
-    Serial.print("Connecting Wifi: ");
-    Serial.println(ssid);
-    WiFi.begin(ssid, password);
-    while (WiFi.status() != WL_CONNECTED)
-    {
-        Serial.print(".");
-        delay(500);
+  if (!LittleFS.begin())
+  {
+    Serial.println("LittleFS initialisation failed!");
+    while (1)
+      yield(); // Stay here twiddling thumbs waiting
+  }
+  Serial.println("\r\nInitialisation done.");
+
+  // Set WiFi to station mode and disconnect from an AP if it was Previously
+  // connected
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect();
+  delay(100);
+
+  // Attempt to connect to Wifi network:
+  Serial.print("Connecting Wifi: ");
+  Serial.println(ssid);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED)
+  {
+    Serial.print(".");
+    delay(500);
     }
     Serial.println("");
     Serial.println("WiFi connected");
@@ -94,8 +139,19 @@ void setup() {
     Serial.println(ip);
 
     // Only avaible in ESP8266 V2.5 RC1 and above
-    client.setFingerprint(SPOTIFY_FINGERPRINT);
+    // client.setFingerprint(SPOTIFY_FINGERPRINT);
 
+    setClock(); // Required for X.509 validation
+
+    int numCerts = certStore.initCertStore(LittleFS, PSTR("/certs.idx"), PSTR("/certs.ar"));
+    Serial.printf("Number of CA certs read: %d\n", numCerts);
+    if (numCerts == 0)
+    {
+      Serial.printf("No certs found. Did you run certs-from-mozilla.py and upload the LittleFS directory before running?\n");
+      return; // Can't connect to anything w/o certs!
+    }
+
+    client.setCertStore(&certStore);
     // If you want to enable some extra debugging
     // uncomment the "#define SPOTIFY_DEBUG" in ArduinoSpotify.h
 

--- a/examples/esp8266/getRefreshToken/certs-from-mozilla.py
+++ b/examples/esp8266/getRefreshToken/certs-from-mozilla.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+# This script pulls the list of Mozilla trusted certificate authorities
+# from the web at the "mozurl" below, parses the file to grab the PEM
+# for each cert, and then generates DER files in a new ./data directory
+# Upload these to an on-chip filesystem and use the CertManager to parse
+# and use them for your outgoing SSL connections.
+#
+# Script by Earle F. Philhower, III.  Released to the public domain.
+from __future__ import print_function
+import csv
+import os
+import sys
+from subprocess import Popen, PIPE, call
+try:
+    from urllib.request import urlopen
+except:
+    from urllib2 import urlopen
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
+
+# Mozilla's URL for the CSV file with included PEM certs
+mozurl = "https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV"
+
+# Load the manes[] and pems[] array from the URL
+names = []
+pems = []
+response = urlopen(mozurl)
+csvData = response.read()
+if sys.version_info[0] > 2:
+    csvData = csvData.decode('utf-8')
+csvFile = StringIO(csvData)
+csvReader = csv.reader(csvFile)
+for row in csvReader:
+    names.append(row[0]+":"+row[1]+":"+row[2])
+    pems.append(row[30])
+del names[0] # Remove headers
+del pems[0] # Remove headers
+
+# Try and make ./data, skip if present
+try:
+    os.mkdir("data")
+except:
+    pass
+
+derFiles = []
+idx = 0
+# Process the text PEM using openssl into DER files
+for i in range(0, len(pems)):
+    certName = "data/ca_%03d.der" % (idx);
+    thisPem = pems[i].replace("'", "")
+    print(names[i] + " -> " + certName)
+    ssl = Popen(['openssl','x509','-inform','PEM','-outform','DER','-out', certName], shell = False, stdin = PIPE)
+    pipe = ssl.stdin
+    pipe.write(thisPem.encode('utf-8'))
+    pipe.close()
+    ssl.wait()
+    if os.path.exists(certName):
+        derFiles.append(certName)
+        idx = idx + 1
+
+if os.path.exists("data/certs.ar"):
+    os.unlink("data/certs.ar");
+
+arCmd = ['ar', 'q', 'data/certs.ar'] + derFiles;
+call( arCmd )
+
+for der in derFiles:
+    os.unlink(der)

--- a/examples/esp8266/playerControls/certs-from-mozilla.py
+++ b/examples/esp8266/playerControls/certs-from-mozilla.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+
+# This script pulls the list of Mozilla trusted certificate authorities
+# from the web at the "mozurl" below, parses the file to grab the PEM
+# for each cert, and then generates DER files in a new ./data directory
+# Upload these to an on-chip filesystem and use the CertManager to parse
+# and use them for your outgoing SSL connections.
+#
+# Script by Earle F. Philhower, III.  Released to the public domain.
+from __future__ import print_function
+import csv
+import os
+import sys
+from subprocess import Popen, PIPE, call
+try:
+    from urllib.request import urlopen
+except:
+    from urllib2 import urlopen
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
+
+# Mozilla's URL for the CSV file with included PEM certs
+mozurl = "https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV"
+
+# Load the manes[] and pems[] array from the URL
+names = []
+pems = []
+response = urlopen(mozurl)
+csvData = response.read()
+if sys.version_info[0] > 2:
+    csvData = csvData.decode('utf-8')
+csvFile = StringIO(csvData)
+csvReader = csv.reader(csvFile)
+for row in csvReader:
+    names.append(row[0]+":"+row[1]+":"+row[2])
+    pems.append(row[30])
+del names[0] # Remove headers
+del pems[0] # Remove headers
+
+# Try and make ./data, skip if present
+try:
+    os.mkdir("data")
+except:
+    pass
+
+derFiles = []
+idx = 0
+# Process the text PEM using openssl into DER files
+for i in range(0, len(pems)):
+    certName = "data/ca_%03d.der" % (idx);
+    thisPem = pems[i].replace("'", "")
+    print(names[i] + " -> " + certName)
+    ssl = Popen(['openssl','x509','-inform','PEM','-outform','DER','-out', certName], shell = False, stdin = PIPE)
+    pipe = ssl.stdin
+    pipe.write(thisPem.encode('utf-8'))
+    pipe.close()
+    ssl.wait()
+    if os.path.exists(certName):
+        derFiles.append(certName)
+        idx = idx + 1
+
+if os.path.exists("data/certs.ar"):
+    os.unlink("data/certs.ar");
+
+arCmd = ['ar', 'q', 'data/certs.ar'] + derFiles;
+call( arCmd )
+
+for der in derFiles:
+    os.unlink(der)


### PR DESCRIPTION
In order to allow ESP8266 HTTPS client to connect to any server and still be secure, the BearSSL HTTPS client allows a certificate store to have all the root certificates necessary to validate any site. The certificates are pulled from a mozilla code repo and compressed into an archive format by an included python script. The archive is uploaded to the LittleFS file system. This requires the installation of the [ESP8266LittleFS plugin (for the IDE)](https://github.com/earlephilhower/arduino-esp8266littlefs-plugin/releases).

The example getRefreshToken was converted to this feature even though it isn't used. Feel free to omit that commit.

