### PR TITLE
Fixed typo: Changed "precent" to "percent" in variable naming

### DIFF
--- a/examples/esp32/getCurrentlyPlaying/getCurrentlyPlaying.ino
+++ b/examples/esp32/getCurrentlyPlaying/getCurrentlyPlaying.ino
@@ -144,12 +144,12 @@ void printCurrentlyPlayingToSerial(CurrentlyPlaying currentlyPlaying)
         Serial.println(duration);
         Serial.println();
 
-        float precentage = ((float)progress / (float)duration) * 100;
-        int clampedPrecentage = (int)precentage;
+        float percentage = ((float)progress / (float)duration) * 100;
+        int clampedPercentage = (int)percentage;
         Serial.print("<");
         for (int j = 0; j < 50; j++)
         {
-            if (clampedPrecentage >= (j * 2))
+            if (clampedPercentage >= (j * 2))
             {
                 Serial.print("=");
             }

--- a/examples/esp32/getDevices/getDevices.ino
+++ b/examples/esp32/getDevices/getDevices.ino
@@ -155,8 +155,8 @@ void printDeviceToSerial(SpotifyDevice device)
     Serial.println("No");
   }
 
-  Serial.print("Volume Precent: ");
-  Serial.println(device.volumePrecent);
+  Serial.print("Volume Percent: ");
+  Serial.println(device.volumePercent);
 
   Serial.println("------------------------");
 }

--- a/examples/esp32/playerDetails/playerDetails.ino
+++ b/examples/esp32/playerDetails/playerDetails.ino
@@ -141,8 +141,8 @@ void printPlayerDetailsToSerial(PlayerDetails playerDetails)
             Serial.println("No");
         }
 
-        Serial.print("Volume Precent: ");
-        Serial.println(playerDetails.device.volumePrecent);
+        Serial.print("Volume Percent: ");
+        Serial.println(playerDetails.device.volumePercent);
 
         Serial.print("Progress (Ms): ");
         Serial.println(playerDetails.progressMs);

--- a/examples/esp8266/getCurrentlyPlaying/getCurrentlyPlaying.ino
+++ b/examples/esp8266/getCurrentlyPlaying/getCurrentlyPlaying.ino
@@ -147,11 +147,11 @@ void printCurrentlyPlayingToSerial(CurrentlyPlaying currentlyPlaying)
         Serial.println(duration);
         Serial.println();
 
-        float precentage = ((float) progress / (float) duration) * 100;
-        int clampedPrecentage = (int)precentage;
+        float percentage = ((float) progress / (float) duration) * 100;
+        int clampedPercentage = (int)percentage;
         Serial.print("<");
         for (int j = 0; j < 50; j++){
-        if(clampedPrecentage >= (j*2)){
+        if(clampedPercentage >= (j*2)){
             Serial.print("=");
         } else {
             Serial.print("-");

--- a/src/ArduinoSpotify.cpp
+++ b/src/ArduinoSpotify.cpp
@@ -655,7 +655,7 @@ PlayerDetails ArduinoSpotify::getPlayerDetails(const char *market)
             playerDetails.device.isActive = device["is_active"].as<bool>();
             playerDetails.device.isPrivateSession = device["is_private_session"].as<bool>();
             playerDetails.device.isRestricted = device["is_restricted"].as<bool>();
-            playerDetails.device.volumePrecent = device["volume_percent"].as<int>();
+            playerDetails.device.volumePercent = device["volume_percent"].as<int>();
 
             playerDetails.progressMs = doc["progress_ms"].as<long>();
             playerDetails.isPlaying = doc["is_playing"].as<bool>();
@@ -761,7 +761,7 @@ int ArduinoSpotify::getDevices(SpotifyDevice devices[], uint8_t maxDevices)
                 devices[i].isActive = device["is_active"].as<bool>();
                 devices[i].isPrivateSession = device["is_private_session"].as<bool>();
                 devices[i].isRestricted = device["is_restricted"].as<bool>();
-                devices[i].volumePrecent = device["volume_percent"].as<int>();
+                devices[i].volumePercent = device["volume_percent"].as<int>();
 
             }
 

--- a/src/ArduinoSpotify.h
+++ b/src/ArduinoSpotify.h
@@ -89,7 +89,7 @@ struct SpotifyDevice
   bool isActive;
   bool isRestricted;
   bool isPrivateSession;
-  int volumePrecent;
+  int volumePercent;
 };
 
 struct PlayerDetails


### PR DESCRIPTION
While working with the library I noticed that "percent" is sometimes misspelled as "precent", most importantly in the naming of the "volumePrecent" attribute of playerDetails.device.