### PR TITLE
retrieve contextUri from currentlyPlaying

### DIFF
--- a/examples/getCurrentlyPlaying/getCurrentlyPlaying.ino
+++ b/examples/getCurrentlyPlaying/getCurrentlyPlaying.ino
@@ -157,6 +157,13 @@ void printCurrentlyPlayingToSerial(CurrentlyPlaying currentlyPlaying)
     Serial.println(currentlyPlaying.albumUri);
     Serial.println();
 
+    if (currentlyPlaying.contextUri != NULL)
+    {
+        Serial.print("Context URI: ");
+        Serial.println(currentlyPlaying.contextUri);
+        Serial.println();
+    }
+
     long progress = currentlyPlaying.progressMs; // duration passed in the song
     long duration = currentlyPlaying.durationMs; // Length of Song
     Serial.print("Elapsed time of song (ms): ");

--- a/src/SpotifyArduino.cpp
+++ b/src/SpotifyArduino.cpp
@@ -538,9 +538,10 @@ int SpotifyArduino::getCurrentlyPlaying(processCurrentlyPlaying currentlyPlaying
         CurrentlyPlaying current;
 
         //Apply Json Filter: https://arduinojson.org/v6/example/filter/
-        StaticJsonDocument<288> filter;
+        StaticJsonDocument<320> filter;
         filter["is_playing"] = true;
         filter["progress_ms"] = true;
+        filter["context"]["uri"] = true;
 
         JsonObject filter_item = filter.createNestedObject("item");
         filter_item["duration_ms"] = true;
@@ -628,6 +629,13 @@ int SpotifyArduino::getCurrentlyPlaying(processCurrentlyPlaying currentlyPlaying
 
             current.progressMs = doc["progress_ms"].as<long>();
             current.durationMs = item["duration_ms"].as<long>();
+
+            // context may be null
+            if( ! doc["context"].isNull() ){
+              current.contextUri = doc["context"]["uri"].as<const char *>();
+            } else {
+              current.contextUri = NULL;
+            }
 
             currentlyPlayingCallback(current);
         }

--- a/src/SpotifyArduino.h
+++ b/src/SpotifyArduino.h
@@ -152,6 +152,7 @@ struct CurrentlyPlaying
   bool isPlaying;
   long progressMs;
   long durationMs;
+  const char *contextUri;
 };
 
 typedef void (*processCurrentlyPlaying)(CurrentlyPlaying currentlyPlaying);


### PR DESCRIPTION
I found the current context URI important to retrieve, as I also use it to play a particular context (album, artist, playlist,...). Maybe this is of use to others.